### PR TITLE
Add "Payment Type Code" to the Debit entry and change Trace Number to a string

### DIFF
--- a/ChoETL.NACHA/ChoNACHABatchWriter.cs
+++ b/ChoETL.NACHA/ChoNACHABatchWriter.cs
@@ -44,9 +44,9 @@ namespace ChoETL.NACHA
             });
         }
 
-        public ChoNACHAEntryDetailWriter CreateDebitEntryDetail(int transactionCode, string RDFIRoutingNumber, string DFIAccountNumber, decimal amount, string individualIDNumber, string individualName, string discretionaryData = null)
+        public ChoNACHAEntryDetailWriter CreateDebitEntryDetail(int transactionCode, string RDFIRoutingNumber, string DFIAccountNumber, decimal amount, string individualIDNumber, string individualName, string discretionaryData = null, string paymentTypeCode = null)
         {
-            return CreateEntryDetail(transactionCode, RDFIRoutingNumber, DFIAccountNumber, amount, individualIDNumber, individualName, discretionaryData, true);
+            return CreateEntryDetail(transactionCode, RDFIRoutingNumber, DFIAccountNumber, amount, individualIDNumber, individualName, discretionaryData, true, paymentTypeCode);
 
         }
 
@@ -55,7 +55,7 @@ namespace ChoETL.NACHA
             return CreateEntryDetail(transactionCode, RDFIRoutingNumber, DFIAccountNumber, amount, individualIDNumber, individualName, discretionaryData, false);
         }
 
-        private ChoNACHAEntryDetailWriter CreateEntryDetail(int transactionCode, string RDFIRoutingNumber, string DFIAccountNumber, decimal amount, string individualIDNumber, string individualName, string discretionaryData = null, bool isDebit = false)
+        private ChoNACHAEntryDetailWriter CreateEntryDetail(int transactionCode, string RDFIRoutingNumber, string DFIAccountNumber, decimal amount, string individualIDNumber, string individualName, string discretionaryData = null, bool isDebit = false, string paymentTypeCode = null)
         {
             CheckDisposed();
 
@@ -74,8 +74,10 @@ namespace ChoETL.NACHA
             _activeEntry.IndividualIDNumber = individualIDNumber;
             _activeEntry.IndividualName = individualName;
             _activeEntry.DiscretionaryData = discretionaryData;
+            if (!String.IsNullOrEmpty(paymentTypeCode))
+                _activeEntry.PaymentTypeCode = paymentTypeCode;
             uint tn = ++_fileRunningStatObject.TraceNumber;
-            _activeEntry.TraceNumber = ulong.Parse(_configuration.DestinationBankRoutingNumber.First(8) + tn.ToString().PadLeft(8, '0'));
+            _activeEntry.TraceNumber = _configuration.DestinationBankRoutingNumber.First(8) + tn.ToString().PadLeft(7, '0');
             _activeEntry.IsDebit = isDebit;
 
             return _activeEntry;

--- a/ChoETL.NACHA/ChoNACHAEntryDetailWriter.cs
+++ b/ChoETL.NACHA/ChoNACHAEntryDetailWriter.cs
@@ -24,8 +24,9 @@ namespace ChoETL.NACHA
         public string IndividualIDNumber { get; set; }
         public string IndividualName { get; set; }
         public string DiscretionaryData { get; set; }
-        public ulong TraceNumber { get; set; }
+        public string TraceNumber { get; set; }
         public bool IsDebit { get; set; }
+        public string PaymentTypeCode { get; set; }
 
         private uint _addendaSeqNo;
 
@@ -78,7 +79,7 @@ namespace ChoETL.NACHA
             _NACHAEntryDetailRecord.IndividualName = IndividualName;
             _NACHAEntryDetailRecord.DiscretionaryData = DiscretionaryData;
             _NACHAEntryDetailRecord.TraceNumber = TraceNumber;
-
+            _NACHAEntryDetailRecord.PaymentTypeCode = PaymentTypeCode;
             _batchRunningStatObject.UpdateStat(_NACHAEntryDetailRecord, IsDebit);
 
             _writer.Write(_NACHAEntryDetailRecord);

--- a/ChoETL.NACHA/Records/ChoNACHAEntryDetailRecord.cs
+++ b/ChoETL.NACHA/Records/ChoNACHAEntryDetailRecord.cs
@@ -91,8 +91,10 @@ namespace ChoETL.NACHA
         /// <summary>
         /// The Bank will assign a trace number.
         /// </summary>
-        [ChoFixedLengthRecordField(79, 15)]
-        [Range(1, ulong.MaxValue, ErrorMessage = "Trace number must be > 0.")]
-        public ulong TraceNumber { get; set; }
+        [ChoFixedLengthRecordField(79, 14)]
+        public string TraceNumber { get; set; }
+
+        [ChoFixedLengthRecordField(77, 1, FieldValueJustification = ChoFieldValueJustification.Right)]
+        public string PaymentTypeCode { get; set; }
     }
 }


### PR DESCRIPTION
Payment Type Code is used for WEB transactions to denote a "S" single transactions or "R" recurring. WEB Column 77-78 left justified, space filled.

Also, ran into a bug with any routing number that starts with zero.  The parse, of course, will drop the leading zero.