### PR TITLE
Ensure proper fill

### DIFF
--- a/ChoETL.NACHA/ChoNACHABatchWriter.cs
+++ b/ChoETL.NACHA/ChoNACHABatchWriter.cs
@@ -44,18 +44,18 @@ namespace ChoETL.NACHA
             });
         }
 
-        public ChoNACHAEntryDetailWriter CreateDebitEntryDetail(int transactionCode, string RDFIRoutingNumber, string DFIAccountNumber, decimal amount, string individualIDNumber, string individualName, string discretionaryData = null)
+        public ChoNACHAEntryDetailWriter CreateDebitEntryDetail(int transactionCode, string RDFIRoutingNumber, string DFIAccountNumber, decimal amount, string individualIDNumber, string individualName, string discretionaryData = null, string paymentTypeCode = null)
         {
-            return CreateEntryDetail(transactionCode, RDFIRoutingNumber, DFIAccountNumber, amount, individualIDNumber, individualName, discretionaryData, true);
+            return CreateEntryDetail(transactionCode, RDFIRoutingNumber, DFIAccountNumber, amount, individualIDNumber, individualName, discretionaryData, true, paymentTypeCode);
 
         }
 
-        public ChoNACHAEntryDetailWriter CreateCreditEntryDetail(int transactionCode, string RDFIRoutingNumber, string DFIAccountNumber, decimal amount, string individualIDNumber, string individualName, string discretionaryData = null)
+        public ChoNACHAEntryDetailWriter CreateCreditEntryDetail(int transactionCode, string RDFIRoutingNumber, string DFIAccountNumber, decimal amount, string individualIDNumber, string individualName, string discretionaryData = null, string paymentTypeCode = null)
         {
-            return CreateEntryDetail(transactionCode, RDFIRoutingNumber, DFIAccountNumber, amount, individualIDNumber, individualName, discretionaryData, false);
+            return CreateEntryDetail(transactionCode, RDFIRoutingNumber, DFIAccountNumber, amount, individualIDNumber, individualName, discretionaryData, false, paymentTypeCode);
         }
 
-        private ChoNACHAEntryDetailWriter CreateEntryDetail(int transactionCode, string RDFIRoutingNumber, string DFIAccountNumber, decimal amount, string individualIDNumber, string individualName, string discretionaryData = null, bool isDebit = false)
+        private ChoNACHAEntryDetailWriter CreateEntryDetail(int transactionCode, string RDFIRoutingNumber, string DFIAccountNumber, decimal amount, string individualIDNumber, string individualName, string discretionaryData = null, bool isDebit = false, string paymentTypeCode = null)
         {
             CheckDisposed();
 
@@ -75,8 +75,10 @@ namespace ChoETL.NACHA
             _activeEntry.IndividualName = individualName;
             _activeEntry.DiscretionaryData = discretionaryData;
             uint tn = ++_fileRunningStatObject.TraceNumber;
-            _activeEntry.TraceNumber = ulong.Parse(_configuration.DestinationBankRoutingNumber.First(8) + tn.ToString().PadLeft(8, '0'));
+            _activeEntry.TraceNumber = _configuration.DestinationBankRoutingNumber.First(8) + tn.ToString().PadLeft(7, '0');
             _activeEntry.IsDebit = isDebit;
+            if (!String.IsNullOrEmpty(paymentTypeCode))
+                _activeEntry.PaymentTypeCode = paymentTypeCode;
 
             return _activeEntry;
 

--- a/ChoETL.NACHA/ChoNACHAEntryDetailWriter.cs
+++ b/ChoETL.NACHA/ChoNACHAEntryDetailWriter.cs
@@ -24,8 +24,9 @@ namespace ChoETL.NACHA
         public string IndividualIDNumber { get; set; }
         public string IndividualName { get; set; }
         public string DiscretionaryData { get; set; }
-        public ulong TraceNumber { get; set; }
+        public string TraceNumber { get; set; }
         public bool IsDebit { get; set; }
+        public string PaymentTypeCode { get; set; }
 
         private uint _addendaSeqNo;
 
@@ -53,7 +54,7 @@ namespace ChoETL.NACHA
             ChoNACHAAddendaRecord addendaRecord = ChoActivator.CreateInstance<ChoNACHAAddendaRecord>();
             addendaRecord.AddendaTypeCode = addendaTypeCode;
             addendaRecord.PaymentRelatedInformation = paymentRelatedInformation;
-            addendaRecord.AddendaSequenceNumber = ++_addendaSeqNo;
+            addendaRecord.AddendaSequenceNumber = ++_addendaSeqNo;  
             addendaRecord.EntryDetailSequenceNumber = ulong.Parse(TraceNumber.ToString().Last(7));
 
             _batchRunningStatObject.UpdateStat(addendaRecord);
@@ -78,6 +79,7 @@ namespace ChoETL.NACHA
             _NACHAEntryDetailRecord.IndividualName = IndividualName;
             _NACHAEntryDetailRecord.DiscretionaryData = DiscretionaryData;
             _NACHAEntryDetailRecord.TraceNumber = TraceNumber;
+            _NACHAEntryDetailRecord.PaymentTypeCode = PaymentTypeCode;
 
             _batchRunningStatObject.UpdateStat(_NACHAEntryDetailRecord, IsDebit);
 

--- a/ChoETL.NACHA/ChoNACHAWriter.cs
+++ b/ChoETL.NACHA/ChoNACHAWriter.cs
@@ -13,7 +13,7 @@ namespace ChoETL.NACHA
         private bool _closeStreamOnDispose = false;
         private ChoManifoldWriter _writer;
         private bool _isDisposed = false;
-        private  ChoNACHABatchWriter _activeBatch = null;
+        private ChoNACHABatchWriter _activeBatch = null;
         private ChoNACHAFileControlRecord _fileControlRecord = null;
         private ChoNACHARunningStat _runningStatObject = new ChoNACHARunningStat();
 
@@ -70,7 +70,7 @@ namespace ChoETL.NACHA
             _fileControlRecord = ChoActivator.CreateInstance<ChoNACHAFileControlRecord>();
         }
 
-        public ChoNACHABatchWriter CreateBatch(int serviceClassCode, string standardEntryClassCode = "PPD", string companyEntryDescription = null, 
+        public ChoNACHABatchWriter CreateBatch(int serviceClassCode, string standardEntryClassCode = "PPD", string companyEntryDescription = null,
             DateTime? companyDescriptiveDate = null, DateTime? effectiveEntryDate = null, string julianSettlementDate = null,
             string companyDiscretionaryData = null, char originatorStatusCode = '1')
         {
@@ -155,7 +155,7 @@ namespace ChoETL.NACHA
             if (Configuration.BlockingFactor <= 0)
                 return;
 
-            uint remain = Configuration.BlockingFactor - _runningStatObject.TotalNoOfRecord % Configuration.BlockingFactor;
+            uint remain = _runningStatObject.TotalNoOfRecord % Configuration.BlockingFactor;
             if (remain <= 0)
                 return;
 
@@ -168,7 +168,7 @@ namespace ChoETL.NACHA
             NACHAFileControlFillerRecord.TotalCreditEntryDollarAmount = 999999999999;
             NACHAFileControlFillerRecord.Reserved = ChoString.Repeat("9", 39);
 
-            for (int i = 0; i < remain; i++)
+            for (int i = 0; i < Configuration.BlockingFactor - remain; i++)
                 _writer.Write(NACHAFileControlFillerRecord);
         }
 

--- a/ChoETL.NACHA/Records/ChoNACHAEntryDetailRecord.cs
+++ b/ChoETL.NACHA/Records/ChoNACHAEntryDetailRecord.cs
@@ -94,7 +94,7 @@ namespace ChoETL.NACHA
         [ChoFixedLengthRecordField(79, 14)]
         public string TraceNumber { get; set; }
 
-        [ChoFixedLengthRecordField(77, 1, FieldValueJustification = ChoFieldValueJustification.Right)]
+        [ChoFixedLengthRecordField(77, 1,FieldValueJustification = ChoFieldValueJustification.Right)]
         public string PaymentTypeCode { get; set; }
     }
 }

--- a/ChoETL.NACHA/Records/ChoNACHAEntryDetailRecord.cs
+++ b/ChoETL.NACHA/Records/ChoNACHAEntryDetailRecord.cs
@@ -94,7 +94,7 @@ namespace ChoETL.NACHA
         [ChoFixedLengthRecordField(79, 14)]
         public string TraceNumber { get; set; }
 
-        [ChoFixedLengthRecordField(77, 1,FieldValueJustification = ChoFieldValueJustification.Right)]
+        [ChoFixedLengthRecordField(77, 1, FieldValueJustification = ChoFieldValueJustification.Right)]
         public string PaymentTypeCode { get; set; }
 
     }


### PR DESCRIPTION
Moved the mod outside scope of the block count subraction.  Old code was creating 10 rows of filler when file was had exactly 10 rows and was not counting the 10 new rows in the block count.  This fix should omit the extra padding and keep the block count accurate.